### PR TITLE
Allow deserializing with a byte array to enable bitcode serde support

### DIFF
--- a/compact_bytes/Cargo.toml
+++ b/compact_bytes/Cargo.toml
@@ -18,6 +18,7 @@ serde = "1"
 static_assertions = "1"
 
 [dev-dependencies]
+bitcode = { version = "0.6.0", features = ["serde"] }
 proptest = "1"
 serde_json = "1"
 test-case = "3"

--- a/compact_bytes/src/lib.rs
+++ b/compact_bytes/src/lib.rs
@@ -542,6 +542,10 @@ fn deserialize_compact_bytes<'de: 'a, 'a, D: serde::Deserializer<'de>>(
         fn visit_borrowed_bytes<E: serde::de::Error>(self, v: &'a [u8]) -> Result<Self::Value, E> {
             Ok(CompactBytes::new(v))
         }
+
+        fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
+            Ok(CompactBytes::new(v))
+        }
     }
 
     deserializer.deserialize_bytes(CompactBytesVisitor)
@@ -762,6 +766,14 @@ mod test {
     use test_strategy::proptest;
 
     use super::{CompactBytes, HeapBytes};
+
+    #[test]
+    fn test_bitcode() {
+        let obj = CompactBytes::new(b"hello world");
+        let encoded = bitcode::serialize(&obj).unwrap();
+        let decoded: CompactBytes = bitcode::deserialize(&encoded).unwrap();
+        assert_eq!(obj.as_slice(), decoded.as_slice());
+    }
 
     #[test]
     #[cfg_attr(miri, ignore)]


### PR DESCRIPTION
Trying to use `bitcode` to deserialize a `CompactBytes` would fail with
```
called `Result::unwrap()` on an `Err` value: Error("invalid type: byte array, expected bytes")
```
in the test I added.

This PR defines the `visit_bytes` deserializer method to avoid that error when using a deserializer that can't ensure the lifetime of the input byte slice will outlive the deserialized value.