### PR TITLE
use the correct capacity when constructing a `HeapBytesGrowable`

### DIFF
--- a/compact_bytes/src/growable.rs
+++ b/compact_bytes/src/growable.rs
@@ -874,4 +874,10 @@ mod test {
         prop_assert_eq!(&repr, &repr_rnd_trip);
         prop_assert_eq!(repr_rnd_trip, ctrl_rnd_trip);
     }
+
+    #[test]
+    fn test_heap_bytes_capacity() {
+        let heap = HeapBytesGrowable::with_capacity(1);
+        drop(heap);
+    }
 }

--- a/compact_bytes/src/lib.rs
+++ b/compact_bytes/src/lib.rs
@@ -122,11 +122,7 @@ impl HeapBytesGrowable {
         let cap = capacity.max(Self::MIN_ALLOCATION_SIZE);
         let ptr = heap::alloc_ptr(cap);
 
-        HeapBytesGrowable {
-            ptr,
-            len,
-            cap: capacity,
-        }
+        HeapBytesGrowable { ptr, len, cap }
     }
 
     pub fn with_additional(slice: &[u8], additional: usize) -> Self {


### PR DESCRIPTION
The `with_capacity` constructor of `HeapBytesGrowable` is using the wrong capacity to initialize the struct which leads to UB when the value is dropped. This behavior cannot be triggered through `CompactBytes` since the capacity is always greater than 16 bytes (which is the `MIN_ALLOCATION_SIZE`).

The most amazing thing about this bug is that it was discovered by Cursor with the following prompt:

> We suspect there is UB in this repo. Review all the unsafe usage of CompactBytes.